### PR TITLE
Fixing README.md to include new kafka-producer-perf-test.sh commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@
 
     /usr/hdp/current/kafka-broker/bin/kafka-producer-perf-test.sh --broker-list c421-node4.sandy.com:6667 --messages 100 --initial-message-id 0001 --topics kafka-spout-test
 
+#### Test Commands working in new Kafka version:
+
+    /usr/hdp/current/kafka-broker/bin/kafka-producer-perf-test.sh  --num-records 2000 --record-size 100 --throughput 2000 --topic kafka-spout-test-1 --producer-props bootstrap.servers=<kafka-broker-fqdn>:6667
+
+    /usr/hdp/current/kafka-broker/bin/kafka-producer-perf-test.sh  --num-records 2000 --record-size 100 --throughput 2000 --topic kafka-spout-test-2 --producer-props bootstrap.servers=<kafka-broker-fqdn>:6667
+
+    /usr/hdp/current/kafka-broker/bin/kafka-producer-perf-test.sh  --num-records 2000 --record-size 100 --throughput 2000 --topic kafka-spout-test --producer-props bootstrap.servers=<kafka-broker-fqdn>:6667
+


### PR DESCRIPTION
I found these commands to be working and old commands to error out on HDP 2.6.5.0-292 running Kafka 1.0.0.